### PR TITLE
Custom deployment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can find a list of all options [below](#options).
 | -h, --help             | Output all available options |
 | -V, --version          | The version tag of the now-serve instance on your device |
 | -c, --cmd [command]    | The command that should be run when starting |
+| -n, --name [name]    | The name for your deployment |
 | -p, --packages &#60;names&#62; | A list of custom packages to add to dependencies (comma-separated) |
 
 ## Contribute

--- a/bin/ns
+++ b/bin/ns
@@ -13,6 +13,7 @@ import hasbin from 'hasbin'
 args
   .option('cmd', 'The command to run when starting')
   .option('packages', 'Custom packages to add to dependencies (comma-separated)')
+  .option('name', 'Custom name for deployment')
 
 const flags = args.parse(process.argv)
 
@@ -58,6 +59,10 @@ if (flags.packages) {
   if (flags.cmd) {
     delete pkgDefaults.dependencies['micro-list']
   }
+}
+
+if (flags.name) {
+  pkgDefaults.name = flags.name;
 }
 
 const pkgContent = JSON.stringify(pkgDefaults, null, 2)


### PR DESCRIPTION
Added support for a custom deployment name, since currently everything you deploy will be named `ns`.

Could be a nice addition. I like my stuff separated ;)